### PR TITLE
Patch to set default symbol when set code is missing

### DIFF
--- a/css/keyrune.css
+++ b/css/keyrune.css
@@ -21,6 +21,10 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+/* default if the set does not exist yet, or setcode does not match */
+.ss:before {
+  content: "\e684";
+}
 /**
  * Larger sizes */
 .ss-2x {

--- a/less/core.less
+++ b/less/core.less
@@ -11,4 +11,8 @@
     /* Better font rendering  */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* default if the set does not exist yet, or setcode does not match */
+    &:before {
+      content: "\e684";
+    }
 }


### PR DESCRIPTION
For set symbols that have yet to be created, or for set codes that miss match, there should be a default. 

In particular, many sites have custom set codes for promos, and they often do not line up.