### PR TITLE
fix scss version of .ss-fw class (issue #67)

### DIFF
--- a/sass/_helpers.scss
+++ b/sass/_helpers.scss
@@ -8,6 +8,13 @@
   }
 }
 
+/** Set Symbol Fix Width =========================
+ */
+.#{$keyrune_prefix}-fw {
+  width: calc(18em / #{$keyrune_font_size / ($keyrune_font_size * 0 + 1)});
+  text-align: center;
+}
+
 /** Set Symbol No Border =========================
  * | This class can remain a singleton since it is generic, making
  * | it a helper class.

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -40,8 +40,7 @@ $keyrune_sizes: (
   '3x': 3em,
   '4x': 4em,
   '5x': 5em,
-  '6x': 6em,
-  'fw': calc(18em / #{$keyrune_font_size})
+  '6x': 6em
 ) !default;
 
 // NOTE: not really sure what to call this array. I notice it is for special borders of sorts, so setlist_borders it is.


### PR DESCRIPTION
The `.ss-fw` class does not work on the scss version.
It set the font-size instead of the width.

Moreover `calc(18em / #{$keyrune_font_size})` is wrong because the right operand of `/` on the calc function must be a number (without units) https://developer.mozilla.org/en-US/docs/Web/CSS/calc. `$keyrune_font_size` is `14px` (with unit). So we need to remove the unit like this:

```
calc(18em / #{$keyrune_font_size / ($keyrune_font_size * 0 + 1)})
```

Last thing: `.ss-fw` class does not set the property `text-align: center;` like the css version.

A possible solution:

```
// _helpers.scss
/** Set Symbol Fix Width Modifiers ===============
 */
.#{$keyrune_prefix}-fw {
  width: calc(18em / #{$keyrune_font_size / ($keyrune_font_size * 0 + 1)});
  text-align: center;
}
```