### PR TITLE
Fixing Copy/Paste error

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -253,7 +253,7 @@ $keyrune_sets: (
     ("Kaldheim Commander", "khc", "\e97d"),
     ("Commander 2021", "c21", "\e97e"),
     ("Forgotten Realms Commander", "afc", "\e981"),
-    ("Jumpstart: Historic Horizons", "afc", "\e983"),
+    ("Jumpstart: Historic Horizons", "j21", "\e983"),
     ("Innistrad: Midnight Hunt Commander", "mic", "\e985"),
     ("Innistrad: Crimson Vow Commander", "voc", "\e986"),
     ("Commander Collection: Black", "cc2", "\e987"),


### PR DESCRIPTION
Jumpstart: Historic Horizons was mislabeled as Adventures in the forgotten realms commander