### PR TITLE
Replace division with non-deprecated syntax

### DIFF
--- a/sass/_helpers.scss
+++ b/sass/_helpers.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 /**
  * Sizes */
 @each $class, $size in $keyrune_sizes {

--- a/sass/_helpers.scss
+++ b/sass/_helpers.scss
@@ -9,7 +9,7 @@
 /**
  * Fixed width */
 .#{$keyrune_prefix}.#{$keyrune_prefix}-fw {
-    width: calc(18em / #{$keyrune_font_size / ($keyrune_font_size * 0 + 1)});
+    width: calc(18em / #{math.div($keyrune_font_size, $keyrune_font_size * 0 + 1)});
     text-align: center;
 }
 

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -10,7 +10,7 @@ $keyrune_font_variant: normal !default;
 $keyrune_font_weight: normal !default;
 $keyrune_font_size:  14px !default;
 $keyrune_font_face: 'Keyrune' !default;
-$keyrune_font: $keyrune_font_style $keyrune_font_variant $keyrune_font_weight $keyrune_font_size/1 $keyrune_font_face !default;
+$keyrune_font: $keyrune_font_style $keyrune_font_variant $keyrune_font_weight calc($keyrune_font_size/1) $keyrune_font_face !default;
 $keyrune_prefix: 'ss' !default;
 $keyrune_default_content: "\e684" !default;
 $keyrune_background_clip: text !default;


### PR DESCRIPTION
This fixes a warning about Dart Sass 2.0.0 removing support for literal division using just the `/` symbol.

Closes #220.