### PR TITLE
Fix WOE set mnemonic

### DIFF
--- a/docs/icons.html
+++ b/docs/icons.html
@@ -435,7 +435,7 @@
                         <span class="name"><i class="ss ss-mat"></i> March of the Machine: The Aftermath <em>(mat)</em></span>
                     </div>
                     <div class="icon" id="woe" name="Wilds of Eldraine" data-name="Wilds of Eldraine" data-class="woe" data-unicode="e9ae" data-added="v3.12.2">
-                        <span class="name"><i class="ss ss-woe"></i> Wilds of Eldraine <em>(mat)</em></span>
+                        <span class="name"><i class="ss ss-woe"></i> Wilds of Eldraine <em>(woe)</em></span>
                     </div>
                     <div class="icon" id="lci" name="Lost Caverns of Ixalan" data-name="Lost Caverns of Ixalan" data-class="lci" data-unicode="e9c2" data-added="v3.13.0">
                         <span class="name"><i class="ss ss-lci"></i> Lost Caverns of Ixalan <em>(lci)</em></span>


### PR DESCRIPTION
Fixes the set code of Wilds of Eldraine on the `icons.htm` page.