### PR TITLE
Update examples.html

### DIFF
--- a/docs/examples.html
+++ b/docs/examples.html
@@ -67,7 +67,7 @@
                     <span class="each"><i class="ss ss-sth ss-6x"></i> ss-6x</span>
                 </div>
                 <div class="explanation">
-                    <p>To conveniently increase the size of a set symbol you can append the classes <code>ss-2x</code>, <code>ss-3x</code>, <code>ss-4x</code>, <code>ss-4x</code>, and <code>ss-6x</code>. These classes increase the size by a factor equal to class name number.</p>
+                    <p>To conveniently increase the size of a set symbol you can append the classes <code>ss-2x</code>, <code>ss-3x</code>, <code>ss-4x</code>, <code>ss-5x</code>, and <code>ss-6x</code>. These classes increase the size by a factor equal to class name number.</p>
                     <blockquote>
                         &lt;<span class="e">i</span> <span class="a">class</span>=<span class="v">"ss ss-sth ss-2x"</span>&gt;&lt;/<span class="e">i</span>&gt; ss-2x<br />
                         &lt;<span class="e">i</span> <span class="a">class</span>=<span class="v">"ss ss-sth ss-3x"</span>&gt;&lt;/<span class="e">i</span>&gt; ss-3x<br />


### PR DESCRIPTION
Fixes a small typo in the symbol sizes explanation:

`ss-4x` -> `ss-5x`